### PR TITLE
fix(manifest): change the image registry to ghcr.

### DIFF
--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -13,5 +13,5 @@ resources:
 # Update the Databend Operator controller manager image tag.
 images:
   - name: datafuselabs/databend-operator
-    newName: electronicwaste/databend-operator
-    newTag: test-v0.0.2
+    newName: ghcr.io/databendcloud/databend-operator/databend-operator
+    newTag: latest


### PR DESCRIPTION
We need to change the image registry to the official ghcr repo of databend-operator

https://github.com/databendcloud/databend-operator/blob/8c9c5af4f678ea244a178465e358f33fff4a09fe/manifests/kustomization.yaml#L13-L17

/cc @flaneur2020 @hantmac @everpcpc 